### PR TITLE
include repository and git SHA information in the generated pacakge

### DIFF
--- a/src/Feliz.Plotly/Feliz.Plotly.fsproj
+++ b/src/Feliz.Plotly/Feliz.Plotly.fsproj
@@ -17,6 +17,7 @@
       compiled JS, so just embed the PDB in the DLL so users can go-to-definition right to the source code -->
     <DebugType>embedded</DebugType>
    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+   <PublishRepositoryUrl>true</PublishRepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`fake build` or `.\build.cmd`) on local branch was successful

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
The Package doesn't have metadata linking it to this repo, so NuGet.org doesn't have a link to the repo.

## What is the new behavior?
The RepositoryUrl property is derived by the build and passed to the packaging step of the build process.

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

Here's what it looks like when viewing a nupkg:

![image](https://github.com/fsprojects/Feliz.Plotly/assets/573979/4ae6d790-9ed2-4aa6-bc40-79d8a98fd4be)

This value will of course be this repo's url when build by someone with `origin` set to this repo. `origin` is just used by the default if not set.

When you have this data set, you get the 'Project website' link in your package's detail page that you can see here:

![image](https://github.com/fsprojects/Feliz.Plotly/assets/573979/00319bb5-0c7a-404b-9eab-678944f23116)
